### PR TITLE
fix: `useGetSemester` hook 로직 및 호출 위치 수정, admin 학기 수정 시 pastSemester도 업데이트 되도록 수정

### DIFF
--- a/src/components/MainCourse/index.tsx
+++ b/src/components/MainCourse/index.tsx
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router-dom';
 import { CancelModal } from '@components';
 
 import { db } from '@config';
-import { useGetSemester, useGetEnrollmentTerm } from '@hooks';
+import { useGetEnrollmentTerm } from '@hooks';
 import { useGetProfile } from '@hooks/use-get-profile';
 import {
   BLACK,
@@ -44,13 +44,20 @@ import {
   StyledOtherLeadersName,
 } from './style';
 
-export const MainCourse = ({ course, profileId }: { course: Course; profileId?: string }) => {
+export const MainCourse = ({
+  course,
+  profileId,
+  currentSemester,
+}: {
+  course: Course;
+  profileId?: string;
+  currentSemester: string;
+}) => {
   const history = useHistory();
 
   const { isEnrollmentTerm } = useGetEnrollmentTerm();
-  
+
   const { user, resetUser } = useGetProfile();
-  const { currentSemester } = useGetSemester();
   const [isLoading, setIsLoading] = useState(false);
   const [isCancelModalVisible, setIsCancelModalVisible] = useState(false);
 
@@ -67,7 +74,6 @@ export const MainCourse = ({ course, profileId }: { course: Course; profileId?: 
     id: courseId,
     maxMemberNum,
     courseMember,
-    courseAttendance,
   } = course;
 
   const onClickApplication = async () => {

--- a/src/hooks/use-get-semester.ts
+++ b/src/hooks/use-get-semester.ts
@@ -4,12 +4,12 @@ import { doc, getDoc } from 'firebase/firestore';
 import { useRecoilState } from 'recoil';
 
 import { db } from '@config/firebase';
-import { currentSemesterState, checkedSemesterState } from '@recoil';
+import { checkedSemesterState, currentSemesterState } from '@recoil';
 
 export const useGetSemester = () => {
   const [currentSemester, setCurrentSemester] = useRecoilState(currentSemesterState);
   const [checkedSemester, setCheckedSemester] = useRecoilState(checkedSemesterState);
-  const [allSemesters, setallSemesters] = useState<string[]>([]);
+  const [allSemesters, setAllSemesters] = useState<string[]>([]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const getCurrentSemester = async () => {
@@ -18,28 +18,20 @@ export const useGetSemester = () => {
     setCurrentSemester(docData?.currentSemester ?? '');
   };
 
-  const getCheckedSemester = async () => {
+  const getAllSemesters = async () => {
     const docRef = doc(db, 'common', 'commonInfo');
     const docData = (await getDoc(docRef)).data();
-    setCheckedSemester(docData?.currentSemester ?? '');
-  };
-
-  const getPastSemester = async () => {
-    const docRef = doc(db, 'common', 'commonInfo');
-    const docData = (await getDoc(docRef)).data();
-    setallSemesters(docData?.pastSemester ? docData?.pastSemester.reverse() : []);
+    setAllSemesters(docData?.pastSemester ? docData?.pastSemester.reverse() : []);
   };
 
   useEffect(() => {
     getCurrentSemester();
+    getAllSemesters();
     if (!checkedSemester) {
-      getCheckedSemester();
+      setCheckedSemester(currentSemester);
     }
-  }, [currentSemester, checkedSemester, getCheckedSemester, setCheckedSemester]);
-
-  useEffect(() => {
-    getPastSemester();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSemester]);
 
   return { currentSemester, setCurrentSemester, checkedSemester, setCheckedSemester, allSemesters };
 };

--- a/src/pages/MainPage/MainCourseTab/index.tsx
+++ b/src/pages/MainPage/MainCourseTab/index.tsx
@@ -5,13 +5,21 @@ import { useRecoilState } from 'recoil';
 // import { useSelector } from "react-redux";
 import { EmptyBox, MainCourse } from '@components';
 
+import { useGetSemester } from '@hooks';
 import { courseTypeTabState, searchLanguageState, searchQueryState } from '@recoil';
-import { StyledCourseTab, StyledTab, StyledTabLine, StyledTabRightLine, StyledTabText } from '@utility/COMMON_STYLE';
+import {
+  StyledCourseTab,
+  StyledTab,
+  StyledTabLine,
+  StyledTabRightLine,
+  StyledTabText,
+} from '@utility/COMMON_STYLE';
 
 import { StyledCourseContainer } from './style';
 
 export const MainCourseTab = ({ mainCourseData }: { mainCourseData: Course[] }) => {
   const [courseTab, setCourseTab] = useRecoilState(courseTypeTabState);
+  const { currentSemester } = useGetSemester();
   const [courseList, setCourseList] = useState<Course[]>([]);
   const [searchQuery] = useRecoilState(searchQueryState);
   const [searchLanguage] = useRecoilState(searchLanguageState);
@@ -66,9 +74,12 @@ export const MainCourseTab = ({ mainCourseData }: { mainCourseData: Course[] }) 
       </StyledCourseTab>
       {courseList.length === 0 && <EmptyBox />}
       {courseList.length > 0 &&
+        currentSemester !== null &&
         courseList.map(res => {
-          if (courseTab === 0) return <MainCourse course={res} key={res.id} />;
-          else if (courseTab === res.courseType) return <MainCourse course={res} key={res.id} />;
+          if (courseTab === 0)
+            return <MainCourse course={res} key={res.id} currentSemester={currentSemester} />;
+          else if (courseTab === res.courseType)
+            return <MainCourse course={res} key={res.id} currentSemester={currentSemester} />;
         })}
     </StyledCourseContainer>
   );

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RouteComponentProps } from 'react-router';
 import { useHistory } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 
 import { EmptyBox, Loading, MainCourse } from '@components';
 import { ProfileModal } from '@components/ProfileModal';
@@ -10,7 +11,8 @@ import { MainContainer } from '@pages/MainPage/style';
 
 import { getUser } from '@apis';
 import { QUERY_KEY } from '@constants';
-import { useGetSemester, useGetProfile } from '@hooks';
+import { useGetProfile, useGetSemester } from '@hooks';
+import { courseTabState } from '@recoil';
 import { PATH } from '@utility/COMMON_FUNCTION';
 import {
   StyledBackArrow,
@@ -38,10 +40,7 @@ import {
   StyledUserDetailComment,
   StyledUserEmoji,
   StyledUserInfoContainer,
-  StyledUserRole,
 } from './style';
-import { useRecoilState } from 'recoil';
-import { courseTabState } from '@recoil';
 
 type CourseTab = 'past' | 'now';
 
@@ -180,9 +179,15 @@ export const ProfilePage = ({ match }: RouteComponentProps<{ id: string }>) => {
           <StyledLine />
           <StyledMainCourseWrapper>
             {courseSemester?.length === 0 && <EmptyBox />}
-            {courseSemester?.map((course: Course, i: number) => (
-              <MainCourse course={course} key={i} profileId={userId} />
-            ))}
+            {currentSemester !== null &&
+              courseSemester?.map((course: Course, i: number) => (
+                <MainCourse
+                  course={course}
+                  key={i}
+                  profileId={userId}
+                  currentSemester={currentSemester}
+                />
+              ))}
           </StyledMainCourseWrapper>
         </StyledCourseContainer>
       </StyledCommonPcLayout>


### PR DESCRIPTION
- `useGetSemester` hook 이 mainCourse 컴포넌트 위치에 있어 컴포넌트 렌더링될 때마다 불필요하게 함께 실행됨 -> mainPage 의 페이지에서 호출하여 자식 컴포넌트 props 로 전달하는 방식으로 수정
- currentSemester가 업데이트될 시 pastSemester 배열도 함께 업데이트 되도록 수정